### PR TITLE
fix: place '...' wildcard at end of meta.json pages array

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -395,9 +395,9 @@ pub async fn generate_course_pages(
         }
 
         // Write major metadata
-        let pages: Vec<String> = std::iter::once("...".to_string())
-            .chain(ordered_semester_folders.iter().cloned())
+        let pages: Vec<String> = ordered_semester_folders.iter().cloned()
             .chain(category_pages.iter().cloned())
+            .chain(std::iter::once("...".to_string()))
             .collect();
 
         let major_meta = serde_json::json!({


### PR DESCRIPTION
## Summary

Fixes the sidebar menu ordering issue reported in [hoa-fuma#110](https://github.com/HITSZ-OpenAuto/hoa-fuma/issues/110).

### Problem

The meta.json files generated for each major placed the `"..."` wildcard at the beginning of the `pages` array. This caused the sidebar to list all items alphabetically, ignoring the intended chronological semester ordering.

### Solution

Reordered the `pages` array construction to put ordered semester folders and category pages first, with the `"..."` wildcard appended at the end to pick up any remaining items.

Before:
```rust
let pages: Vec<String> = std::iter::once("...".to_string())
    .chain(ordered_semester_folders.iter().cloned())
    .chain(category_pages.iter().cloned())
    .collect();
```

After:
```rust
let pages: Vec<String> = ordered_semester_folders.iter().cloned()
    .chain(category_pages.iter().cloned())
    .chain(std::iter::once("...".to_string()))
    .collect();
```

A companion defensive fix has also been submitted to `hoa-fuma` at https://github.com/HITSZ-OpenAuto/hoa-fuma/pull/112.