### PR TITLE
perf: format source READMEs before generation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -124,7 +124,18 @@ async fn main() -> Result<()> {
         fs::create_dir_all(&docs_dir)?;
     }
 
+    // Format source README files before generation
+    println!("Formatting source MDX files...");
+    let fmt_start = std::time::Instant::now();
+    let modified_count = formatter::format_all_mdx_files(&repos_dir)?;
+    println!(
+        "Formatted {} source MDX files in {:.2?}",
+        modified_count,
+        fmt_start.elapsed()
+    );
+
     println!("Generating course pages...");
+    let gen_start = std::time::Instant::now();
     generator::generate_course_pages(
         &plans,
         &shared_categories_config.categories,
@@ -135,12 +146,10 @@ async fn main() -> Result<()> {
         &repos_set,
     )
     .await?;
-    println!("Course pages generated successfully");
-
-    // Format MDX files
-    println!("Formatting MDX files...");
-    let modified_count = formatter::format_all_mdx_files(&docs_dir)?;
-    println!("Formatted {} MDX files", modified_count);
+    println!(
+        "Course pages generated successfully in {:.2?}",
+        gen_start.elapsed()
+    );
 
     println!("\n✓ Done! All pages generated and formatted.");
 


### PR DESCRIPTION
## Summary

Moves MDX formatting from the generated output (`content/docs`, 7,178 files) to the fetched source READMEs (`repos/`, 142 files), running it **before** the generator instead of after.

Part of the groundwork for #14: once formatting is a source-level concern, the same transformations can be reported as lint errors against course READMEs, and the formatter can eventually be retired.

## Why

Every transformation in `formatter.rs` targets author-written README content (Hugo shortcodes, `<br>`, HTML comments, math delimiters, etc.). None of it is needed for generator output — the generator already emits clean frontmatter and JSX. Formatting after generation meant:

- Each course page duplicated across majors/semesters was formatted repeatedly (7,178 files instead of 142 sources)
- Trusted generator output was rewritten by regexes, which is pure risk (e.g. a `$` in a generated `<Files>` tree could be mangled by inline-math conversion)

## Benchmark (full dataset: 142 repos, 12,595 courses, 16,705 generated files)

| Variant | Format | Generate |
|---|---|---|
| Before (format `content/docs` after) | ~6.5s | ~1.75s |
| After (format `repos/` first) | ~75ms | ~1.70s |

~87× faster formatting, ~4.6× faster format+generate overall. Timings are the median of 3 runs each.

## Correctness

`diff -r` between the old and new pipeline's `content/docs`: **byte-identical** across all 16,705 files.

`cargo test`: 84 pass, 2 fail — the same 2 tests fail on unmodified `main` (stale assertions about the missing-repo notice text from 58b492c), unrelated to this change.

## Notes

- `repos/` is now formatted in place. It's a gitignored fetch cache and the fetcher skips existing files, so re-runs are no-ops. A follow-up could format in memory instead to keep the cache pristine for the future lint mode.
- Step timing `println!`s were added while benchmarking and kept in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)